### PR TITLE
Take instances of Read by value isntead of mutable references

### DIFF
--- a/src/format/pixel_format.rs
+++ b/src/format/pixel_format.rs
@@ -59,7 +59,7 @@ pub struct PixelFormat {
 }
 
 impl PixelFormat {
-    pub fn read<R: Read>(r: &mut R) -> Result<PixelFormat, Error>
+    pub fn read<R: Read>(mut r: R) -> Result<PixelFormat, Error>
     {
         let size = r.read_u32::<LittleEndian>()?;
         if size != 32 {

--- a/src/header.rs
+++ b/src/header.rs
@@ -203,7 +203,7 @@ impl Header {
         Ok(header)
     }
 
-    pub fn read<R: Read>(r: &mut R) -> Result<Header, Error>
+    pub fn read<R: Read>(mut r: R) -> Result<Header, Error>
     {
         let size = r.read_u32::<LittleEndian>()?;
         if size != 124 {
@@ -219,7 +219,7 @@ impl Header {
         let mip_map_count = r.read_u32::<LittleEndian>()?;
         let mut reserved1 = [0_u32; 11];
         r.read_u32_into::<LittleEndian>(&mut reserved1)?;
-        let spf = PixelFormat::read(r)?;
+        let spf = PixelFormat::read(&mut r)?;
         let caps = r.read_u32::<LittleEndian>()?;
         let caps2 = r.read_u32::<LittleEndian>()?;
         let caps3 = r.read_u32::<LittleEndian>()?;

--- a/src/header10.rs
+++ b/src/header10.rs
@@ -92,7 +92,7 @@ impl Header10 {
         }
     }
 
-    pub fn read<R: Read>(r: &mut R) -> Result<Header10, Error>
+    pub fn read<R: Read>(mut r: R) -> Result<Header10, Error>
     {
         let dxgi_format = r.read_u32::<LittleEndian>()?;
         let resource_dimension = r.read_u32::<LittleEndian>()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,16 +130,16 @@ impl Dds {
     }
 
     /// Read a DDS file
-    pub fn read<R: Read>(r: &mut R) -> Result<Dds, Error> {
+    pub fn read<R: Read>(mut r: R) -> Result<Dds, Error> {
         let magic = r.read_u32::<LittleEndian>()?;
         if magic != Self::MAGIC {
             return Err(Error::BadMagicNumber);
         }
 
-        let header = Header::read(r)?;
+        let header = Header::read(&mut r)?;
 
         let header10 = if header.spf.fourcc == Some(FourCC(<FourCC>::DX10)) {
-            Some(Header10::read(r)?)
+            Some(Header10::read(&mut r)?)
         } else {
             None
         };


### PR DESCRIPTION
This changes 4 function signatures to take the `impl Read` instances by value instead of mutable references. The reasoning behind this is the following:

The standard library contains these two impls:

```
impl<'a, R: Read + ?Sized> Read for &'a mut R { /* ... */ }

impl<'a, W: Write + ?Sized> Write for &'a mut W { /* ... */ }
```

That means any function that accepts R: Read or W: Write generic parameters by value can be called with a mut reference if necessary.

In the documentation of such functions, briefly remind users that a mut reference can be passed. New Rust users often struggle with this. They may have opened a file and want to read multiple pieces of data out of it, but the function to read one piece consumes the reader by value, so they are stuck. The solution would be to leverage one of the above impls and pass &mut f instead of f as the reader parameter.

Taken from https://rust-lang.github.io/api-guidelines/interoperability.html?highlight=Read#generic-readerwriter-functions-take-r-read-and-w-write-by-value-c-rw-value