### PR TITLE
Add a DEPTH header flag in `new_d3d`/`new_dxgi` if `depth` is set.

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -123,6 +123,7 @@ impl Header {
         if let Some(d) = depth {
             if d > 1 {
                 header.caps.insert(Caps::COMPLEX);
+                header.flags |= HeaderFlags::DEPTH;
             }
         }
 
@@ -171,6 +172,7 @@ impl Header {
         if let Some(d) = depth {
             if d > 1 {
                 header.caps.insert(Caps::COMPLEX);
+                header.flags |= HeaderFlags::DEPTH;
             }
         }
         if let Some(al) = array_layers {


### PR DESCRIPTION
I'm not sure how important this is, but it is correct to do this.