### PR TITLE
Include depth in linear_size calculation

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -138,10 +138,12 @@ impl Header {
             None => return Err(Error::UnsupportedFormat),
         };
 
+        let depth = depth.unwrap_or(1);
+
         if compressed {
             header.flags = header.flags | HeaderFlags::LINEARSIZE;
             header.linear_size = Some(
-                pitch * height / format.get_pitch_height()
+                pitch * height * depth / format.get_pitch_height()
             );
         } else {
             header.flags = header.flags | HeaderFlags::PITCH;
@@ -192,10 +194,12 @@ impl Header {
             None => return Err(Error::UnsupportedFormat),
         };
 
+        let depth = depth.unwrap_or(1);
+
         if compressed {
             header.flags = header.flags | HeaderFlags::LINEARSIZE;
             header.linear_size = Some(
-                pitch * height / format.get_pitch_height()
+                pitch * height * depth / format.get_pitch_height()
             );
         } else {
             header.flags = header.flags | HeaderFlags::PITCH;


### PR DESCRIPTION
[This page on the DDS_HEADER structure](https://docs.microsoft.com/en-us/windows/win32/direct3ddds/dds-header) states that `linear_size` is 'the total number of bytes in the top level texture for a compressed texture.', so we should include depth in this as well.