### PR TITLE
Set MIPMAPCOUNT flag when writing a mipmapped D3D file

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -117,6 +117,7 @@ impl Header {
 
         if let Some(mml) = mipmap_levels {
             if mml > 1 {
+                header.flags.insert(HeaderFlags::MIPMAPCOUNT);
                 header.caps.insert(Caps::COMPLEX | Caps::MIPMAP);
             }
         }


### PR DESCRIPTION
GIMP assumes the file has 0 mipmaps, so doesn't import any mipmaps, if
this flag is not set.