### PR TITLE
Add the `CUBEMAP_ALLFACES` flag on `Caps2`

### DIFF
--- a/src/format/d3d.rs
+++ b/src/format/d3d.rs
@@ -315,7 +315,8 @@ impl D3DFormat {
             let alpha = pixel_format.flags.contains(PixelFormatFlags::ALPHA)
                 || pixel_format.flags.contains(PixelFormatFlags::ALPHA_PIXELS);
             let lum = pixel_format.flags.contains(PixelFormatFlags::LUMINANCE);
-            match (
+            #[rustfmt::skip]
+            let format = match (
                 lum,
                 rgb,
                 alpha,
@@ -325,8 +326,6 @@ impl D3DFormat {
                 pixel_format.b_bit_mask,
                 pixel_format.a_bit_mask
             ) {
-                // NOTE: The following block is intentionally not formatted according to rustfmt standards.
-                //       Please keep it this way as this is much easier to read.
                 // lum     rgb   alpha  rgb cnt         r bitmask         g bitmask         b bitmask         a bitmask
                 (  false,  true,  true, Some(32), Some(      0xff), Some(    0xff00), Some(  0xff0000), Some(0xff000000)) => Some(D3DFormat::A8B8G8R8),
                 (  false,  true, false, Some(32), Some(    0xffff), Some(0xffff0000), None,             None            ) => Some(D3DFormat::G16R16),
@@ -348,7 +347,8 @@ impl D3DFormat {
                 (   true, false, false, Some( 8), Some(      0xff), None,             None,             None            ) => Some(D3DFormat::L8),
                 (   true, false,  true, Some( 8), Some(       0xf), None,             None,             Some(      0xf0)) => Some(D3DFormat::A4L4),
                 _ => None
-            }
+            };
+            format
         }
     }
 }

--- a/src/format/dxgi.rs
+++ b/src/format/dxgi.rs
@@ -20,10 +20,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-use enum_primitive_derive::Primitive;
 use super::pixel_format::{FourCC, PixelFormat};
 use super::DataFormat;
+use enum_primitive_derive::Primitive;
 
+#[rustfmt::skip]
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Primitive)]
 #[repr(u32)]
@@ -149,7 +150,6 @@ pub enum DxgiFormat {
     V408                        = 132,
     Force_UInt                  = 0xffffffff_u32
 }
-
 
 impl DataFormat for DxgiFormat {
     fn get_pitch(&self, width: u32) -> Option<u32> {

--- a/src/header.rs
+++ b/src/header.rs
@@ -377,5 +377,12 @@ bitflags! {
         const CUBEMAP_NEGATIVEZ = 0x8000;
         /// Required for a volume texture
         const VOLUME = 0x200000;
+        /// Identical to setting all cubemap direction flags
+        const CUBEMAP_ALLFACES = Self::CUBEMAP_POSITIVEX.bits()
+            | Self::CUBEMAP_NEGATIVEX.bits()
+            | Self::CUBEMAP_POSITIVEY.bits()
+            | Self::CUBEMAP_NEGATIVEY.bits()
+            | Self::CUBEMAP_POSITIVEZ.bits()
+            | Self::CUBEMAP_NEGATIVEZ.bits();
     }
 }


### PR DESCRIPTION
`CUBEMAP_ALLFACES` is an utility flag for checking that a cubemap is complete that seems defined in the DDS format definition header [according to this doc](https://learn.microsoft.com/en-us/windows/win32/direct3ddds/dds-header).

I also took the liberty of adding `[rustfmt::skip]` in the two places where special indentation was used, sadly as attributes on expressions aren't stable that meant adding an additional binding in one case.